### PR TITLE
Release/2.2.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ log.transports.file.format = '{h}:{i}:{s}:{ms} {text}';
 // the archived log will be saved as the log.old.log file
 log.transports.file.maxSize = 5 * 1024 * 1024;
 
+// Set maximum log files count. When it exceeds,
+// oldest old log file is deleted.
+log.transports.file.maxItems = 4;
+
+// Set timestamp format postfixed to log file.
+log.transports.file.timeStampPostfixFormat = '{y}{m}{d}{h}{i}{s}';
+
 // Write to this file, must be set before first logging
 log.transports.file.file = __dirname + '/log.txt';
 
@@ -134,6 +141,14 @@ but please be aware that transport configuration is available only
 inside the main process.
 
 ## Change Log
+
+**2.2.19**
+
+- Enabled log file rotation.
+  By default log file is archived with datetimestamp postfixed to the log file name when max size limit is reached.
+  When total number of files including active and archived log files is exceeded transports.file.maxItems, oldest old log file is deleted and this is repeated.
+- Enabled configuring datetimestamp postfix format attached to archived log file by using transports.file.timeStampPostfixFormat.
+  Here datetimestamp values are all refering UTC time values.
 
 **2.2.18**
 

--- a/lib/format.js
+++ b/lib/format.js
@@ -5,6 +5,7 @@ var EOL  = require('os').EOL;
 
 module.exports = {
   format: format,
+  formatTimeStamp: formatTimeStamp,
   formatTimeZone: formatTimeZone,
   pad: pad,
   stringifyArray: stringifyArray
@@ -16,10 +17,15 @@ function format(msg, formatter) {
   }
 
   var date = msg.date;
-
-  return formatter
+  var timeStampFormatter = formatter
     .replace('{level}', msg.level)
-    .replace('{text}', stringifyArray(msg.data))
+    .replace('{text}', stringifyArray(msg.data));
+
+  return formatTimeStamp(timeStampFormatter, date);
+}
+
+function formatTimeStamp(formatter, date) {
+  return formatter
     .replace('{y}', date.getFullYear())
     .replace('{m}', pad(date.getMonth() + 1))
     .replace('{d}', pad(date.getDate()))

--- a/lib/transports/file/index.js
+++ b/lib/transports/file/index.js
@@ -11,6 +11,7 @@ transport.format                 = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {te
 transport.timeStampPostfixFormat = '{y}{m}{d}{h}{i}{s}';
 transport.level                  = 'warn';
 transport.maxSize                = 1024 * 1024;
+transport.maxItems               = 4;
 transport.streamConfig           = undefined;
 
 module.exports = transport;
@@ -85,7 +86,6 @@ function archiveLog(stream) {
   // Ensure that there are only 2 old log files maximum at this moment.
   try {
     var allFiles = fs.readdirSync(folderPath);
-    var files = [];
     var postfixes = [];
     var converted = null;
     var i = 0;
@@ -97,13 +97,12 @@ function archiveLog(stream) {
           converted = 0;
         }
         postfixes.push(converted);
-        files.push(allFiles[i]);
       }
     }
     
     postfixes.sort(function(a, b) { return a - b; });
 
-    for (i = 0; i < files.length - 2; i++) {
+    for (i = 0; i < postfixes.length - (transport.maxItems - 2); i++) {
       fs.unlinkSync(stream.path + '-' + postfixes[i]);
     }
   } catch (e) {

--- a/lib/transports/file/index.js
+++ b/lib/transports/file/index.js
@@ -6,11 +6,12 @@ var format           = require('../../format');
 var consoleTransport = require('../console');
 var findLogPath      = require('./find-log-path');
 
-transport.findLogPath  = findLogPath;
-transport.format       = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}';
-transport.level        = 'warn';
-transport.maxSize      = 1024 * 1024;
-transport.streamConfig = undefined;
+transport.findLogPath            = findLogPath;
+transport.format                 = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}';
+transport.timeStampPostfixFormat = '{y}{m}{d}{h}{i}{s}';
+transport.level                  = 'warn';
+transport.maxSize                = 1024 * 1024;
+transport.streamConfig           = undefined;
 
 module.exports = transport;
 
@@ -78,9 +79,41 @@ function archiveLog(stream) {
     stream.end();
   }
 
+  var logFileName = stream.path.substring(stream.path.lastIndexOf('/') + 1);
+  var folderPath = stream.path.substring(0, stream.path.lastIndexOf('/'));
+
+  // Ensure that there are only 2 old log files maximum at this moment.
   try {
-    // Rename file extension to old.XXX
-    fs.renameSync(stream.path, stream.path.replace(/\.([^.]*)$/, '.old.$1'));
+    var allFiles = fs.readdirSync(folderPath);
+    var files = [];
+    var postfixes = [];
+    var converted = null;
+    var i = 0;
+
+    for (i = 0; i < allFiles.length; i++) {
+      if (allFiles[i].includes(logFileName + '-')) {
+        converted = parseInt(allFiles[i].substring(logFileName.length + 1), 10);
+        if (isNaN(converted)) {
+          converted = 0;
+        }
+        postfixes.push(converted);
+        files.push(allFiles[i]);
+      }
+    }
+    
+    postfixes.sort(function(a, b) { return a - b; });
+
+    for (i = 0; i < files.length - 2; i++) {
+      fs.unlink(stream.path + '-' + postfixes[i]);
+    }
+  } catch (e) {
+    logConsole('Could not read log directory contents');
+  }
+
+  // Archive active log file to new one with timestamp
+  try {
+    var postfix = format.formatTimeStamp(transport.timeStampPostfixFormat, new Date());
+    fs.renameSync(stream.path, stream.path + '-' + postfix);
   } catch (e) {
     logConsole('Could not rotate log', e);
   }

--- a/lib/transports/file/index.js
+++ b/lib/transports/file/index.js
@@ -112,7 +112,10 @@ function archiveLog(stream) {
 
   // Archive active log file to new one with timestamp
   try {
-    var postfix = format.formatTimeStamp(transport.timeStampPostfixFormat, new Date());
+    var now = new Date();
+    var timezoneOffset = now.getTimezoneOffset();
+    now.setHours(now.getHours() + timezoneOffset / 60);
+    var postfix = format.formatTimeStamp(transport.timeStampPostfixFormat, now);
     fs.renameSync(stream.path, stream.path + '-' + postfix);
   } catch (e) {
     logConsole('Could not rotate log', e);

--- a/lib/transports/file/index.js
+++ b/lib/transports/file/index.js
@@ -104,7 +104,7 @@ function archiveLog(stream) {
     postfixes.sort(function(a, b) { return a - b; });
 
     for (i = 0; i < files.length - 2; i++) {
-      fs.unlink(stream.path + '-' + postfixes[i]);
+      fs.unlinkSync(stream.path + '-' + postfixes[i]);
     }
   } catch (e) {
     logConsole('Could not read log directory contents');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-log-daedalus",
-  "version": "2.2.18",
+  "version": "2.2.19",
   "description": "Just a very simple logging module for your Electron application",
   "main": "./index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   ],
   "author": "Alexey Prokhorov",
   "contributors": [
-    "Dominik Guzei"
+    "Dominik Guzei",
+    "Yakov Karavelov"
   ],
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
**2.2.19**

 - Enabled log file rotation.
  By default log file is archived with datetimestamp postfixed to the log file name when max size limit is reached.
  When total number of files including active and archived log files is exceeded transports.file.maxItems, oldest old log file is deleted and this is repeated.
- Enabled configuring datetimestamp postfix format attached to archived log file by using transports.file.timeStampPostfixFormat.
  Here datetimestamp values are all refering UTC time values.